### PR TITLE
fix(double-reading-response) #WPB-11546

### DIFF
--- a/src/main/java/com/wire/helium/API.java
+++ b/src/main/java/com/wire/helium/API.java
@@ -258,7 +258,7 @@ public class API extends LoginClient implements WireAPI {
 
         if (response.getStatus() >= 400) {
             String msgError = response.readEntity(String.class);
-            Logger.error("DownloadAsset http error %s. AssetId: %s", response.readEntity(String.class), assetKey);
+            Logger.error("DownloadAsset http error %s, status: %d. AssetId: %s", msgError, response.getStatus(), assetKey);
             throw new HttpException(msgError, response.getStatus());
         }
 


### PR DESCRIPTION
Remove second reading of error body in downloadAsset #WPB-11546

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Could not report specific error on downloadAsset

### Causes (Optional)

Difficulties debugging asset api call

### Solutions

Read error body once

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
