### PR TITLE
Update nexus-staging-maven-plugin from v1.6.7 to v.1.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When releasing to Sonatype it is failing due to nexus maven plugin version

### Causes (Optional)

Old issue from old version on nexus

### Solutions

Update to v1.6.13