### PR TITLE
chore(add-exceptions-when-mls-handling-fails) #WPB-12152

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 target/
 data/
 libs/
+mls/
 .classpath
 .project
 .settings

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>helium</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 
     <name>Helium</name>
     <description>User mode for Wire Bots</description>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>xenon</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>


### PR DESCRIPTION
* Update Helium to 1.5.1
* Update Xenon to 1.7.1
* Adjust wrong used http response on isMlsEnabled
* Add proper handling and throwing of exception for:
 - uploadClientPublicKey
 - uploadClientKeyPackages
 - getConversationGroupInfo
 - getConversationGroupInfo
* Ignore mls/ folder from .gitignore

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some methods for MLS handling were not throwing exceptions correctly

### Solutions

Add proper handling of throwing exceptions

### Dependencies (Optional)

This PR is to be merged after release of Xenon 1.7.1

Needs releases with:

- [ ] [Xenon - Handle mls-welcome events, creating necessary data with core-crypto #WPB-12154 #111](https://github.com/wireapp/xenon/pull/111)

### Testing

Tests are done one level above (Legalhold)