### PR TITLE
chore(close-potential-network-leaks)

### DIFF
--- a/src/main/java/com/wire/helium/API.java
+++ b/src/main/java/com/wire/helium/API.java
@@ -370,12 +370,13 @@ public class API extends LoginClient implements WireAPI {
                 header(HttpHeaders.AUTHORIZATION, bearer(token)).
                 delete();
 
-        if (response.getStatus() >= 400) {
+        if (isErrorResponse(response.getStatus())) {
             String msgError = response.readEntity(String.class);
             Logger.error("DeleteConversation http error: %s, status: %d", msgError, response.getStatus());
             throw new HttpException(msgError, response.getStatus());
         }
 
+        response.close();
         return response.getStatus() == 200;
     }
 
@@ -393,11 +394,13 @@ public class API extends LoginClient implements WireAPI {
                 header(HttpHeaders.AUTHORIZATION, bearer(token)).
                 post(Entity.entity(service, MediaType.APPLICATION_JSON));
 
-        if (response.getStatus() >= 400) {
+        if (isErrorResponse(response.getStatus())) {
             String msgError = response.readEntity(String.class);
             Logger.error("AddService http error: %s, status: %d", msgError, response.getStatus());
             throw new HttpException(msgError, response.getStatus());
         }
+
+        response.close();
     }
 
     @Override
@@ -413,11 +416,13 @@ public class API extends LoginClient implements WireAPI {
                 header(HttpHeaders.AUTHORIZATION, bearer(token)).
                 post(Entity.entity(newConv, MediaType.APPLICATION_JSON));
 
-        if (response.getStatus() >= 400) {
+        if (isErrorResponse(response.getStatus())) {
             String msgError = response.readEntity(String.class);
             Logger.error("AddParticipants http error: %s, status: %d", msgError, response.getStatus());
             throw new HttpException(msgError, response.getStatus());
         }
+
+        response.close();
     }
 
     @Override
@@ -481,11 +486,13 @@ public class API extends LoginClient implements WireAPI {
                 .header(HttpHeaders.AUTHORIZATION, bearer(token))
                 .delete();
 
-        if (response.getStatus() >= 400) {
+        if (isErrorResponse(response.getStatus())) {
             String msgError = response.readEntity(String.class);
             Logger.error("LeaveConversation http error: %s, status: %d", msgError, response.getStatus());
             throw new HttpException(msgError, response.getStatus());
         }
+
+        response.close();
     }
 
     /**
@@ -571,6 +578,7 @@ public class API extends LoginClient implements WireAPI {
             final NotificationList emptyNotifications = new NotificationList();
             emptyNotifications.hasMore = false;
             emptyNotifications.notifications = new ArrayList<>();
+            response.close();
             return emptyNotifications;
         } else if (status == 401) {   // Nginx returns text/html for 401. Cannot deserialize as json
             response.readEntity(String.class);
@@ -703,9 +711,10 @@ public class API extends LoginClient implements WireAPI {
 
             Logger.error(errorMessage);
             throw new RuntimeException(errorResponse);
-        } else if(isSuccessResponse(response.getStatus())) {
-            Logger.info("uploadClientPublicKey success for clientId: %s", clientId);
         }
+
+        Logger.info("uploadClientPublicKey success for clientId: %s", clientId);
+        response.close();
     }
 
     /**
@@ -734,15 +743,16 @@ public class API extends LoginClient implements WireAPI {
         if (isErrorResponse(response.getStatus())) {
             String errorResponse = response.readEntity(String.class);
             String errorMessage = String.format(
-                "getConversationGroupInfo error: %s, clientId: %s, status: %d",
+                "uploadClientKeyPackages error: %s, clientId: %s, status: %d",
                 errorResponse, clientId, response.getStatus()
             );
 
             Logger.error(errorMessage);
             throw new RuntimeException(errorResponse);
-        } else if(isSuccessResponse(response.getStatus())) {
-            Logger.info("uploadClientKeyPackages success for clientId: %s", clientId);
         }
+
+        Logger.info("uploadClientKeyPackages success for clientId: %s", clientId);
+        response.close();
     }
 
     @Override
@@ -778,6 +788,7 @@ public class API extends LoginClient implements WireAPI {
 
         if (isSuccessResponse(response.getStatus())) {
             Logger.info("commitMlsBundle success.");
+            response.close();
             return;
         }
 

--- a/src/main/java/com/wire/helium/LoginClient.java
+++ b/src/main/java/com/wire/helium/LoginClient.java
@@ -233,6 +233,8 @@ public class LoginClient {
         } else if (status >= 400) {
             throw response.readEntity(HttpException.class);
         }
+
+        response.close();
     }
 
     public void removeCookies(String token, String password) throws HttpException {
@@ -255,6 +257,7 @@ public class LoginClient {
             throw response.readEntity(HttpException.class);
         }
 
+        response.close();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
Some functions were propitious to leak the network response object from not closing them properly.

Added missing response.close() to:
* API.java
* LoginClient.java

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some API functions were throwing this exception on the logs:
```
ConnectionPoolTimeoutException: Timeout waiting for connection from pool
```

But unfortunately we don't have the stack trace anymore.

### Causes (Optional)

We forgot to call `response.close();` on some functions.

Note: We either call `response.close();` or `response.readEntity(Something.class);` so the network is properly closed.

### Solutions

Add `response.close();` to functions missing it in `API.java` and `LoginClient.java`
