### PR TITLE
fix(add client_id param to token refresh) #WPB-12153

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>helium</artifactId>
-    <version>1.5.2</version>
+    <version>1.6.0</version>
 
     <name>Helium</name>
     <description>User mode for Wire Bots</description>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.wire</groupId>
             <artifactId>xenon</artifactId>
-            <version>1.7.2</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/src/main/java/com/wire/helium/API.java
+++ b/src/main/java/com/wire/helium/API.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.protobuf.ByteString;
 import com.wire.helium.models.Connection;
-import com.wire.helium.models.model.response.FeatureConfig;
 import com.wire.helium.models.NotificationList;
-import com.wire.helium.models.model.response.PublicKeysResponse;
 import com.wire.helium.models.model.request.ConversationListPaginationConfig;
 import com.wire.helium.models.model.request.ConversationListRequest;
 import com.wire.helium.models.model.response.ConversationListIdsResponse;
 import com.wire.helium.models.model.response.ConversationListResponse;
+import com.wire.helium.models.model.response.FeatureConfig;
+import com.wire.helium.models.model.response.PublicKeysResponse;
 import com.wire.messages.Otr;
 import com.wire.xenon.WireAPI;
 import com.wire.xenon.assets.IAsset;
@@ -93,14 +93,13 @@ public class API extends LoginClient implements WireAPI {
 
     /**
      * Sends E2E encrypted messages to all clients already known, with opened cryptobox sessions.
-     *
      * After sending those, the backend will return the list of clients that the service has no connection yet,
      * so prekeys for those specific clients can be downloaded a new cryptobox sessions initiated.
      * @param msg the message with the already encrypted clients
      * @param ignoreMissing when true, missing clients won't be blocking and just be returned,
      *                      when false, any missing recipient will block the message to be sent to anyone
      * @return devices that had issues or still need the message
-     * @throws HttpException
+     * @throws HttpException on any error response from the backend
      */
     @Override
     public Devices sendMessage(OtrMessage msg, boolean ignoreMissing) throws HttpException {
@@ -137,13 +136,12 @@ public class API extends LoginClient implements WireAPI {
 
     /**
      * Sends E2E encrypted messages to all clients already known, with opened cryptobox sessions.
-     *
      * After sending those, the backend will return the list of clients that the service has no connection yet,
      * so prekeys for those specific clients can be downloaded a new cryptobox sessions initiated.
      * @param msg the message with the already encrypted clients
      * @param userId If this users' client is missing, the message is not sent
      * @return devices that had issues or still need the message
-     * @throws HttpException
+     * @throws HttpException on any error response from the backend
      */
     @Override
     public Devices sendPartialMessage(OtrMessage msg, QualifiedId userId) throws HttpException {
@@ -669,7 +667,7 @@ public class API extends LoginClient implements WireAPI {
             }
 
             try {
-                PublicKeysResponse publicKeysResponse = mlsPublicKeysResponse.readEntity(PublicKeysResponse.class);
+                mlsPublicKeysResponse.readEntity(PublicKeysResponse.class);
             } catch (Exception e) {
                 Logger.error("isMlsEnabled - Public Keys Deserialization error: %s", e.getMessage());
                 return false;
@@ -761,7 +759,7 @@ public class API extends LoginClient implements WireAPI {
             .path(conversationId.domain)
             .path(conversationId.id.toString())
             .path("groupinfo")
-            .request(MediaType.APPLICATION_JSON)
+            .request()
             .header(HttpHeaders.AUTHORIZATION, bearer(token))
             .accept("message/mls")
             .get();

--- a/src/main/java/com/wire/helium/LoginClient.java
+++ b/src/main/java/com/wire/helium/LoginClient.java
@@ -185,10 +185,11 @@ public class LoginClient {
         return response.readEntity(_Client.class).id;
     }
 
-    public Access renewAccessToken(Cookie cookie) throws HttpException {
+    public Access renewAccessToken(String clientId, Cookie cookie) throws HttpException {
         Invocation.Builder builder = accessPath
-                .request(MediaType.APPLICATION_JSON)
-                .cookie(cookie);
+            .queryParam("client_id", clientId)
+            .request(MediaType.APPLICATION_JSON)
+            .cookie(cookie);
 
         Response response = builder.
                 post(Entity.entity(null, MediaType.APPLICATION_JSON));

--- a/src/test/java/com/wire/helium/End2EndTest.java
+++ b/src/test/java/com/wire/helium/End2EndTest.java
@@ -51,7 +51,7 @@ public class End2EndTest extends DatabaseTestBase {
 
         CryptoDatabase aliceCrypto = new CryptoDatabase(aliceId, storage, rootFolder + "/testAliceToAlice/1");
         CryptoDatabase aliceCrypto1 = new CryptoDatabase(aliceId, storage, rootFolder + "/testAliceToAlice/2");
-        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, client1 + "_db_key");
+        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, aliceId, client1 + "_db_key");
 
         DummyAPI api = new DummyAPI();
         api.addDevice(aliceId, client1, aliceCrypto1.box().newLastPreKey());
@@ -81,7 +81,7 @@ public class End2EndTest extends DatabaseTestBase {
 
         CryptoDatabase aliceCrypto = new CryptoDatabase(aliceId, storage, rootFolder + "/testAliceToBob");
         CryptoDatabase bobCrypto = new CryptoDatabase(bobId, storage, rootFolder + "/testAliceToBob");
-        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, client1 + "_db_key");
+        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, bobId,  client1 + "_db_key");
 
         DummyAPI api = new DummyAPI();
         api.addDevice(bobId, client1, bobCrypto.box().newLastPreKey());
@@ -116,7 +116,7 @@ public class End2EndTest extends DatabaseTestBase {
         CryptoDatabase aliceCrypto1 = new CryptoDatabase(aliceId, storage, rootFolder + "/testMultiDevicePostgres/alice/1");
         CryptoDatabase bobCrypto1 = new CryptoDatabase(bobId, storage, rootFolder + "/testMultiDevicePostgres/bob/1");
         CryptoDatabase bobCrypto2 = new CryptoDatabase(bobId, storage, rootFolder + "/testMultiDevicePostgres/bob/2");
-        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, client1 + "_db_key");
+        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client1, bobId, client1 + "_db_key");
 
         DummyAPI api = new DummyAPI();
         api.addDevice(bobId, client1, bobCrypto1.box().newLastPreKey());


### PR DESCRIPTION
* Update tests to use fully qualified client ids
* Remove redundant accept json mediatype while getting conversation groupInfo
* Bump to 1.6.0

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Renewing access tokens was not client specific.

### Causes (Optional)

Backend did not accept our MLS commit bundles with an authorization that did not indicate the client

### Solutions

Add client_id param to the /access call used to get access tokens

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
